### PR TITLE
Proto file path

### DIFF
--- a/src/device/Device.ts
+++ b/src/device/Device.ts
@@ -44,14 +44,14 @@ export class Device {
      * 
      * @param callback this is an optional call back showing if protobuf successfully initialized
      */
-    constructor(callback?: (success: boolean) => void) {
+    constructor(callback?: (success: boolean) => void, pathToProtoFile?: string) {
         this.pb = Protobuf.Instance;
         if (!this.pb.IsInited) {
             this.pb.Init((isSuccess: boolean) => {
                 if(callback) {
                     callback(isSuccess);
                 }
-            });
+            }, pathToProtoFile);
         } else if(callback) {
             callback(true);
         }

--- a/src/protobuf/Protobuf.ts
+++ b/src/protobuf/Protobuf.ts
@@ -39,8 +39,11 @@ export class Protobuf {
         return this._instance;
     }
 
-    Init(callback?: (isSuccess: boolean) => void): void {
+    Init(callback?: (isSuccess: boolean) => void, protoPath?: string): void {
         let address = '/assets/data/protob/combined.proto.txt';
+        if(protoPath != undefined){
+            address = `${protoPath}/combined.proto.txt`;
+        }
 
         const opt: IParseOptions = {
             keepCase: true,

--- a/src/protobuf/Protobuf.ts
+++ b/src/protobuf/Protobuf.ts
@@ -41,7 +41,7 @@ export class Protobuf {
 
     Init(callback?: (isSuccess: boolean) => void, protoPath?: string): void {
         let address = '/assets/data/protob/combined.proto.txt';
-        if(protoPath != undefined){
+        if(protoPath != null){
             address = `${protoPath}/combined.proto.txt`;
         }
 


### PR DESCRIPTION
The path to proto file can be optionally passed to Device class constructor.

Example:

let device = new Device((success: boolean) => {....}, 'directory-path-which-contains-combined.proto.txt');